### PR TITLE
Fix connection closed on pause

### DIFF
--- a/main.py
+++ b/main.py
@@ -90,6 +90,9 @@ class MainScreen(FloatLayout):
 
 
 class RemoteKivyApp(App):
+    def on_pause(self):
+        return True
+    
     def build(self):
         global app
         app = self


### PR DESCRIPTION
Hi,

I suggest you add these two lines of code to avoid closing the ssh connection every time the application loses focus.

In my case, I used your application to test a Python code using the USB host mode API. The use of this API requires the permission of the user, so Android displays a dialog box to ask for it. And when this dialog box appears, the application is paused and this causes the connection reset.